### PR TITLE
feat(tests): Improve test coverage for base loader (#54)

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:f9670692591b2bcfcdbb2d9a5c36c789e2c440e10583693796b2ed4101726883"
+content_hash = "sha256:ee89533510e8d1abf25a3378da0dfee24ef893e28b490dd2975c3a0e404f0920"
 
 [[metadata.targets]]
 requires_python = ">=3.10"

--- a/tests/unit/test_loader_base.py
+++ b/tests/unit/test_loader_base.py
@@ -76,3 +76,22 @@ def test_concrete_loader_instantiation_and_method_calls():
     assert ingestion_state is None
     loader.save_ingestion_state(history_record, "schema")
     loader.close_connection()
+
+
+def test_incomplete_loader_raises_type_error():
+    """
+    Tests that instantiating a class that inherits from LoaderInterface but
+    does not implement all abstract methods raises a TypeError.
+    """
+    import pytest
+
+    with pytest.raises(TypeError) as excinfo:
+
+        class IncompleteLoader(LoaderInterface):
+            def prepare_schema(self, dsd, table_name, schema, rep, meta_schema) -> None:
+                return super().prepare_schema(
+                    dsd, table_name, schema, rep, meta_schema
+                )
+        IncompleteLoader()
+
+    assert "Can't instantiate abstract class" in str(excinfo.value)


### PR DESCRIPTION
This commit improves the test coverage of the project by adding a new test for the `LoaderInterface` abstract base class in `src/py_load_eurostat/loader/base.py`.

The new test, `test_incomplete_loader_raises_type_error`, verifies that attempting to instantiate a subclass of `LoaderInterface` without implementing all of its abstract methods correctly raises a `TypeError`. This is a standard and recommended way to test the contract of an abstract base class.

This change addresses the low test coverage in `base.py` in a way that is consistent with good software design principles, as confirmed by a code review.