### PR TITLE
Fix tests, ensure PEP conformance, and prepare for PyPI submission (#56)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,7 @@ addopts = "-ra -q --cov=src/py_load_eurostat --cov-report=term-missing"
 testpaths = [
     "tests",
 ]
-# python_paths is not a standard option and raises a warning, using PYTHONPATH instead
-# python_paths = "src"
+pythonpath = ["src", "."]
 markers = [
     "integration: marks tests as integration tests",
 ]

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -1,8 +1,6 @@
-import pytest
 from typer.testing import CliRunner
 
 from py_load_eurostat.cli import app
-from py_load_eurostat.config import AppSettings
 
 
 def test_pipeline_network_error(httpserver, monkeypatch, tmp_path):
@@ -13,9 +11,7 @@ def test_pipeline_network_error(httpserver, monkeypatch, tmp_path):
     httpserver.expect_request(
         "/eurostat/api/dissemination/statistics/1.0/data/tps00001"
     ).respond_with_data("Internal Server Error", 500)
-    monkeypatch.setenv(
-        "PY_LOAD_EUROSTAT_EUROSTAT__BASE_URL", httpserver.url_for("/")
-    )
+    monkeypatch.setenv("PY_LOAD_EUROSTAT_EUROSTAT__BASE_URL", httpserver.url_for("/"))
     db_path = tmp_path / "test.db"
     monkeypatch.setenv("PY_LOAD_EUROSTAT_DB__NAME", str(db_path))
     monkeypatch.setenv("PY_LOAD_EUROSTAT_DB_TYPE", "sqlite")
@@ -55,9 +51,7 @@ def test_pipeline_parsing_error(httpserver, monkeypatch, tmp_path):
     httpserver.expect_request(
         "/eurostat/api/dissemination/sdmx/2.1/dataflow/ESTAT/tps00001"
     ).respond_with_data("malformed xml", 200)
-    monkeypatch.setenv(
-        "PY_LOAD_EUROSTAT_EUROSTAT__BASE_URL", httpserver.url_for("/")
-    )
+    monkeypatch.setenv("PY_LOAD_EUROSTAT_EUROSTAT__BASE_URL", httpserver.url_for("/"))
     db_path = tmp_path / "test.db"
     monkeypatch.setenv("PY_LOAD_EUROSTAT_DB__NAME", str(db_path))
     monkeypatch.setenv("PY_LOAD_EUROSTAT_DB_TYPE", "sqlite")

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -7,13 +7,12 @@ import logging
 from pathlib import Path
 
 import pytest
-from psycopg.rows import class_row, dict_row
+from psycopg.rows import dict_row
 from pytest_httpserver import HTTPServer
 
 from py_load_eurostat import pipeline
 from py_load_eurostat.config import AppSettings, DatabaseSettings
 from py_load_eurostat.loader.postgresql import PostgresLoader
-from py_load_eurostat.models import IngestionHistory
 
 # Set a logger for debugging the test
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_integration_postgres_loader.py
+++ b/tests/integration/test_integration_postgres_loader.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 
 import pytest
 from psycopg.rows import dict_row
+from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 from testcontainers.postgres import PostgresContainer
 
 from py_load_eurostat.config import DatabaseSettings
@@ -26,15 +27,15 @@ from py_load_eurostat.models import (
 )
 
 
-from testcontainers.core.wait_strategies import LogMessageWaitStrategy
-
 @pytest.fixture(scope="module")
 def postgres_container():
     """
     Spins up a PostgreSQL container for the test module.
     """
     postgres = PostgresContainer("postgres:16-alpine")
-    postgres.waiting_for(LogMessageWaitStrategy("database system is ready to accept connections"))
+    postgres.waiting_for(
+        LogMessageWaitStrategy("database system is ready to accept connections")
+    )
     with postgres:
         yield postgres
 
@@ -258,13 +259,15 @@ def test_prepare_schema_is_idempotent_with_fks(
         # 4. Verify that the table and FKs still exist
         with loader.conn.cursor() as cur:
             cur.execute(
-                "SELECT 1 FROM information_schema.tables WHERE table_name = %s AND table_schema = %s",
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = %s AND table_schema = %s",
                 (table_name, data_schema),
             )
             assert cur.fetchone() is not None, "Table should still exist"
 
             cur.execute(
-                "SELECT 1 FROM information_schema.table_constraints WHERE constraint_name = %s",
+                "SELECT 1 FROM information_schema.table_constraints "
+                "WHERE constraint_name = %s",
                 (f"fk_{table_name}_geo",),
             )
             assert cur.fetchone() is not None, "Foreign key should still exist"

--- a/tests/unit/test_loader_base.py
+++ b/tests/unit/test_loader_base.py
@@ -89,9 +89,8 @@ def test_incomplete_loader_raises_type_error():
 
         class IncompleteLoader(LoaderInterface):
             def prepare_schema(self, dsd, table_name, schema, rep, meta_schema) -> None:
-                return super().prepare_schema(
-                    dsd, table_name, schema, rep, meta_schema
-                )
+                return super().prepare_schema(dsd, table_name, schema, rep, meta_schema)
+
         IncompleteLoader()
 
     assert "Can't instantiate abstract class" in str(excinfo.value)

--- a/tests/unit/test_loader_factory.py
+++ b/tests/unit/test_loader_factory.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
+
 from py_load_eurostat.config import AppSettings, DatabaseSettings, DatabaseType
 from py_load_eurostat.loader.factory import get_loader
 from py_load_eurostat.loader.postgresql import PostgresLoader

--- a/tests/unit/test_loader_sqlite_extra.py
+++ b/tests/unit/test_loader_sqlite_extra.py
@@ -1,15 +1,18 @@
-import pytest
 import sqlite3
-from py_load_eurostat.loader.sqlite import SQLiteLoader
-from py_load_eurostat.models import DSD, Measure, Dimension
+
+import pytest
+
 from py_load_eurostat.config import DatabaseSettings
-from tests.unit.test_loader_sqlite import sample_dsd
+from py_load_eurostat.loader.sqlite import SQLiteLoader
+from py_load_eurostat.models import DSD, Dimension, Measure
+
 
 @pytest.fixture
 def db_settings_extra(tmp_path):
     """Fixture for a temporary database for extra tests."""
     db_file = tmp_path / "test_extra.db"
     return DatabaseSettings(name=str(db_file))
+
 
 def test_get_required_columns_no_primary_measure(db_settings_extra):
     """
@@ -24,7 +27,7 @@ def test_get_required_columns_no_primary_measure(db_settings_extra):
         dimensions=[Dimension(id="geo", name="Geo", position=0, data_type="String")],
         measures=[Measure(id="WRONG_ID", name="Some other measure")],
         primary_measure_id="OBS_VALUE",
-        attributes=[]
+        attributes=[],
     )
 
     columns = loader._get_required_columns(dsd_no_measure)
@@ -33,6 +36,7 @@ def test_get_required_columns_no_primary_measure(db_settings_extra):
     assert "OBS_VALUE" in columns
     assert columns["OBS_VALUE"] == "REAL"
     assert "geo" in columns
+
 
 def test_prepare_schema_rollback_on_error(db_settings_extra, sample_dsd):
     """
@@ -54,6 +58,9 @@ def test_prepare_schema_rollback_on_error(db_settings_extra, sample_dsd):
     cursor = conn.cursor()
     # The fqn will be 'main__invalid.table', which is not a valid identifier
     # We can check if any table was created with a name like 'main__invalid'
-    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'main__invalid%'")
+    cursor.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name LIKE 'main__invalid%'"
+    )
     tables = cursor.fetchall()
     assert len(tables) == 0

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -275,14 +275,13 @@ def test_tsv_parser_malformed_dim_string(mocker, tmp_path):
     Tests that TsvParser handles rows with malformed dimension strings (NaN).
     """
     # 1. Arrange: Mock pandas.read_csv to return a chunk with a NaN value
-    mock_chunk = pd.DataFrame(
-        {"unit,geo\\time": [pd.NA], "2022": [100.0]}
-    )
+    mock_chunk = pd.DataFrame({"unit,geo\\time": [pd.NA], "2022": [100.0]})
     mocker.patch("pandas.read_csv", return_value=iter([mock_chunk]))
 
     # We still need a valid-looking file for the header parsing to work
     dummy_path = tmp_path / "dummy.tsv.gz"
     import gzip
+
     with gzip.open(dummy_path, "wt") as f:
         f.write("unit,geo\\time\t2022\n")
 

--- a/tests/unit/test_parser_edge_cases.py
+++ b/tests/unit/test_parser_edge_cases.py
@@ -1,10 +1,11 @@
-import pytest
-from pathlib import Path
-from py_load_eurostat.parser import SdmxParser, TsvParser
-import xml.etree.ElementTree as ET
 import gzip
-import pandas as pd
+from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
+
+from py_load_eurostat.parser import SdmxParser, TsvParser
+
 
 @pytest.fixture
 def malformed_tsv_file(tmp_path: Path) -> Path:
@@ -18,6 +19,7 @@ def malformed_tsv_file(tmp_path: Path) -> Path:
     with gzip.open(file_path, "wt", encoding="utf-8") as f:
         f.write(content)
     return file_path
+
 
 @pytest.fixture
 def dsd_xml_with_codelist_map(tmp_path: Path) -> Path:
@@ -48,8 +50,11 @@ def dsd_xml_with_codelist_map(tmp_path: Path) -> Path:
     file_path.write_text(content)
     return file_path
 
+
 def test_parse_dsd_from_dataflow_no_structures(mocker):
-    """Test that parse_dsd_from_dataflow raises ValueError when SDMX has no structures."""
+    """
+    Test that parse_dsd_from_dataflow raises ValueError when SDMX has no structures.
+    """
     mock_message = MagicMock()
     mock_message.structures = []
     mocker.patch("py_load_eurostat.parser.read_sdmx", return_value=mock_message)
@@ -57,6 +62,7 @@ def test_parse_dsd_from_dataflow_no_structures(mocker):
 
     with pytest.raises(ValueError, match="No structures found in the SDMX message"):
         parser.parse_dsd_from_dataflow(Path("dummy/path.sdmx"))
+
 
 def test_parse_codelist_no_structures(mocker):
     """Test that parse_codelist raises ValueError when SDMX has no structures."""
@@ -68,6 +74,7 @@ def test_parse_codelist_no_structures(mocker):
     with pytest.raises(ValueError, match="No structures found in the SDMX message"):
         parser.parse_codelist(Path("dummy/path.sdmx"))
 
+
 def test_extract_codelist_map_from_xml(dsd_xml_with_codelist_map: Path):
     """Test the _extract_codelist_map_from_xml method directly."""
     parser = SdmxParser()
@@ -76,6 +83,7 @@ def test_extract_codelist_map_from_xml(dsd_xml_with_codelist_map: Path):
         "dim1": "CL_DIM1",
         "dim2": "CL_DIM2",
     }
+
 
 def test_tsv_parser_with_malformed_row(malformed_tsv_file: Path):
     """Test that the TsvParser can handle rows with non-string dimension values."""
@@ -88,7 +96,7 @@ def test_tsv_parser_with_malformed_row(malformed_tsv_file: Path):
     df = processed_chunks[0]
 
     # The row's dimensions should be a list of Nones
-    assert df.iloc[0]['unit'] is None
-    assert df.iloc[0]['sex'] is None
-    assert df.iloc[0]['age'] is None
-    assert df.iloc[0]['geo'] is None
+    assert df.iloc[0]["unit"] is None
+    assert df.iloc[0]["sex"] is None
+    assert df.iloc[0]["age"] is None
+    assert df.iloc[0]["geo"] is None

--- a/tests/unit/test_parser_extra.py
+++ b/tests/unit/test_parser_extra.py
@@ -1,9 +1,12 @@
-import pytest
 import gzip
 from pathlib import Path
+
+import pytest
+
+from py_load_eurostat.models import DSD, Dimension
 from py_load_eurostat.parser import TsvParser
 from py_load_eurostat.transformer import Transformer
-from py_load_eurostat.models import DSD, Dimension
+
 
 @pytest.fixture
 def sample_dsd_for_parser():
@@ -21,57 +24,57 @@ def sample_dsd_for_parser():
         primary_measure_id="OBS_VALUE",
     )
 
+
 @pytest.fixture
 def tsv_file_factory(tmp_path):
     """A factory to create temporary gzipped TSV files for testing."""
+
     def _factory(content: bytes) -> Path:
         file_path = tmp_path / "test.tsv.gz"
         with gzip.open(file_path, "wb") as f:
             f.write(content)
         return file_path
+
     return _factory
+
 
 def test_parse_tsv_with_missing_values(sample_dsd_for_parser, tsv_file_factory):
     """Test parsing a TSV file with ':' for missing values.
     The transformer should drop these values."""
-    tsv_content = (
-        b"freq,geo\\TIME_PERIOD\t2022\t2023\n"
-        b"A,DE\t100.0\t:\n"
-        b"A,FR\t:\t200.0\n"
-    )
+    tsv_content = b"freq,geo\\TIME_PERIOD\t2022\t2023\nA,DE\t100.0\t:\nA,FR\t:\t200.0\n"
     tsv_path = tsv_file_factory(tsv_content)
     parser = TsvParser(tsv_path)
     transformer = Transformer(sample_dsd_for_parser, {})
 
     wide_df_iterator, dim_cols, time_cols = parser.parse()
-    data_stream = transformer.transform(wide_df_iterator, dim_cols, time_cols, "Standard")
+    data_stream = transformer.transform(
+        wide_df_iterator, dim_cols, time_cols, "Standard"
+    )
     data = list(data_stream)
 
     # The transformer drops missing values, so we expect only 2 records.
     assert len(data) == 2
 
     assert data[0].value == 100.0
-    assert data[0].dimensions['geo'] == 'DE'
-    assert data[0].time_period == '2022'
+    assert data[0].dimensions["geo"] == "DE"
+    assert data[0].time_period == "2022"
 
     assert data[1].value == 200.0
-    assert data[1].dimensions['geo'] == 'FR'
-    assert data[1].time_period == '2023'
+    assert data[1].dimensions["geo"] == "FR"
+    assert data[1].time_period == "2023"
 
 
 def test_parse_tsv_with_status_flags(sample_dsd_for_parser, tsv_file_factory):
     """Test parsing a TSV file with status flags."""
-    tsv_content = (
-        b"freq,geo\\TIME_PERIOD\t2022\n"
-        b"A,DE\t100.0 p\n"
-        b"A,FR\t200.0 e\n"
-    )
+    tsv_content = b"freq,geo\\TIME_PERIOD\t2022\nA,DE\t100.0 p\nA,FR\t200.0 e\n"
     tsv_path = tsv_file_factory(tsv_content)
     parser = TsvParser(tsv_path)
     transformer = Transformer(sample_dsd_for_parser, {})
 
     wide_df_iterator, dim_cols, time_cols = parser.parse()
-    data_stream = transformer.transform(wide_df_iterator, dim_cols, time_cols, "Standard")
+    data_stream = transformer.transform(
+        wide_df_iterator, dim_cols, time_cols, "Standard"
+    )
     data = list(data_stream)
 
     assert len(data) == 2
@@ -80,19 +83,18 @@ def test_parse_tsv_with_status_flags(sample_dsd_for_parser, tsv_file_factory):
     assert data[1].value == 200.0
     assert data[1].flags == "e"
 
+
 def test_parse_tsv_with_trailing_spaces(sample_dsd_for_parser, tsv_file_factory):
     """Test parsing a TSV file with trailing spaces after values."""
-    tsv_content = (
-        b"freq,geo\\TIME_PERIOD\t2022\n"
-        b"A,DE\t100.0 \n"
-        b"A,FR\t200.0  \n"
-    )
+    tsv_content = b"freq,geo\\TIME_PERIOD\t2022\nA,DE\t100.0 \nA,FR\t200.0  \n"
     tsv_path = tsv_file_factory(tsv_content)
     parser = TsvParser(tsv_path)
     transformer = Transformer(sample_dsd_for_parser, {})
 
     wide_df_iterator, dim_cols, time_cols = parser.parse()
-    data_stream = transformer.transform(wide_df_iterator, dim_cols, time_cols, "Standard")
+    data_stream = transformer.transform(
+        wide_df_iterator, dim_cols, time_cols, "Standard"
+    )
     data = list(data_stream)
 
     assert len(data) == 2
@@ -100,6 +102,7 @@ def test_parse_tsv_with_trailing_spaces(sample_dsd_for_parser, tsv_file_factory)
     assert data[0].flags is None
     assert data[1].value == 200.0
     assert data[1].flags is None
+
 
 def test_parse_tsv_with_multiple_frequencies(sample_dsd_for_parser, tsv_file_factory):
     """Test parsing a TSV with mixed annual and quarterly data."""
@@ -113,7 +116,9 @@ def test_parse_tsv_with_multiple_frequencies(sample_dsd_for_parser, tsv_file_fac
     transformer = Transformer(sample_dsd_for_parser, {})
 
     wide_df_iterator, dim_cols, time_cols = parser.parse()
-    data_stream = transformer.transform(wide_df_iterator, dim_cols, time_cols, "Standard")
+    data_stream = transformer.transform(
+        wide_df_iterator, dim_cols, time_cols, "Standard"
+    )
     data = list(data_stream)
 
     # The transformer will drop missing values, so we expect 3 records.

--- a/tests/unit/test_postgres_loader_unit.py
+++ b/tests/unit/test_postgres_loader_unit.py
@@ -1,7 +1,8 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
+
 from py_load_eurostat.loader.postgresql import PostgresLoader
-from py_load_eurostat.config import DatabaseSettings
 
 
 @pytest.mark.parametrize(
@@ -26,26 +27,12 @@ from py_load_eurostat.config import DatabaseSettings
 def test_normalize_pg_type(input_type, expected_type):
     """Test that _normalize_pg_type correctly normalizes various PG type strings."""
     # We don't need a real connection for this test
-    db_settings = DatabaseSettings(
-        host="localhost",
-        port=5432,
-        user="user",
-        password="password",
-        name="testdb",
-    )
     loader = PostgresLoader.__new__(PostgresLoader)
     assert loader._normalize_pg_type(input_type) == expected_type
 
 
 def test_finalize_merge_raises_error_if_dsd_is_not_set():
     """Test that _finalize_merge raises a RuntimeError if DSD is not set."""
-    db_settings = DatabaseSettings(
-        host="localhost",
-        port=5432,
-        user="user",
-        password="password",
-        name="testdb",
-    )
     # Create a loader instance without a real connection
     loader = PostgresLoader.__new__(PostgresLoader)
     loader.dsd = None
@@ -56,19 +43,12 @@ def test_finalize_merge_raises_error_if_dsd_is_not_set():
 
 def test_close_connection_handles_closed_and_none_connections():
     """Test that close_connection can be called multiple times safely."""
-    db_settings = DatabaseSettings(
-        host="localhost",
-        port=5432,
-        user="user",
-        password="password",
-        name="testdb",
-    )
     # Create a loader instance without a real connection for the first part
     loader = PostgresLoader.__new__(PostgresLoader)
 
     # Test with conn = None
     loader.conn = None
-    loader.close_connection() # Should not raise
+    loader.close_connection()  # Should not raise
 
     # Test with a mock connection
     mock_conn = MagicMock()


### PR DESCRIPTION
This commit addresses several issues to prepare the package for PyPI submission.

- Fixes a test collection error (`ModuleNotFoundError: No module named 'tests'`) by adding the correct `pythonpath` to the `pyproject.toml` configuration for pytest. This removes the need for developers to manually set the `PYTHONPATH` environment variable.
- Enforces PEP conformance by running `ruff` to format the code and fix linting errors. This includes removing unused variables and imports, and reformatting long lines.
- Verifies that the `LICENSE` file is present and valid.
- Confirms that the package can be successfully built into a source distribution and wheel using `pdm build`.

These changes ensure that the test suite runs reliably, the code adheres to style standards, and the package is ready for distribution.