### PR TITLE
Fix: Correct dependency installation and resolve test failures (#60)

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ee89533510e8d1abf25a3378da0dfee24ef893e28b490dd2975c3a0e404f0920"
+content_hash = "sha256:5e064aa9530ac057d28697399fa03cc879c31d2b70005b9ddb58797c9561e782"
 
 [[metadata.targets]]
 requires_python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ py-load-eurostat = "py_load_eurostat.cli:app"
 Homepage = "https://github.com/example/py_load_eurostat"
 Repository = "https://github.com/example/py_load_eurostat"
 
-[project.optional-dependencies]
+[tool.pdm.dev-dependencies]
 dev = [
     "pytest",
     "pytest-cov",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+
+from py_load_eurostat.models import (
+    DSD,
+    Attribute,
+    Dimension,
+)
+
+
+@pytest.fixture
+def sample_dsd():
+    """A sample DSD fixture for testing."""
+    from py_load_eurostat.models import Measure
+
+    return DSD(
+        id="SAMPLE_DSD",
+        name="Sample DSD",
+        version="1.0",
+        dimensions=[
+            Dimension(id="geo", name="Geo", position=0, codelist_id="CL_GEO"),
+            Dimension(id="freq", name="Frequency", position=1, codelist_id="CL_FREQ"),
+        ],
+        attributes=[Attribute(id="OBS_FLAG", name="Observation Flag")],
+        measures=[Measure(id="OBS_VALUE", name="Observation Value")],
+        primary_measure_id="OBS_VALUE",
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from py_load_eurostat.config import AppSettings, DatabaseType
 
 
-def test_settings_load_from_env_file(tmp_path: Path):
+def test_settings_load_from_env_file(tmp_path: Path, monkeypatch):
     """
     Verify that settings are correctly loaded from a .env file.
     """
@@ -15,6 +15,11 @@ def test_settings_load_from_env_file(tmp_path: Path):
     )
     env_file = tmp_path / ".env"
     env_file.write_text(env_content)
+
+    # Unset environment variables that might interfere with the test
+    monkeypatch.delenv("PY_LOAD_EUROSTAT_DB_TYPE", raising=False)
+    monkeypatch.delenv("PY_LOAD_EUROSTAT_DB__NAME", raising=False)
+    monkeypatch.delenv("PY_LOAD_EUROSTAT_LOG__LEVEL", raising=False)
 
     # 2. Instantiate the settings object, passing the path to the .env file directly.
     settings = AppSettings(_env_file=env_file)

--- a/tests/unit/test_loader_sqlite.py
+++ b/tests/unit/test_loader_sqlite.py
@@ -16,23 +16,6 @@ from py_load_eurostat.models import (
 )
 
 
-@pytest.fixture
-def sample_dsd():
-    """A sample DSD fixture for testing."""
-    from py_load_eurostat.models import Measure
-
-    return DSD(
-        id="SAMPLE_DSD",
-        name="Sample DSD",
-        version="1.0",
-        dimensions=[
-            Dimension(id="geo", name="Geo", position=0, codelist_id="CL_GEO"),
-            Dimension(id="freq", name="Frequency", position=1, codelist_id="CL_FREQ"),
-        ],
-        attributes=[Attribute(id="OBS_FLAG", name="Observation Flag")],
-        measures=[Measure(id="OBS_VALUE", name="Observation Value")],
-        primary_measure_id="OBS_VALUE",
-    )
 
 
 @pytest.fixture


### PR DESCRIPTION
This commit addresses the GitHub Actions CI failures caused by `pytest` not being found in the PATH.

The key changes include:
- Moving the development dependencies from `[project.optional-dependencies]` to `[tool.pdm.dev-dependencies]` in `pyproject.toml`. This ensures that `pdm install -d` correctly installs `pytest` and other development tools.
- Updating `tests/unit/test_config.py` to use `monkeypatch` to unset environment variables during a specific test, making the test more robust and isolated from the execution environment.
- Creating a `tests/unit/conftest.py` file and moving the shared `sample_dsd` fixture into it. This resolves a `fixture not found` error and improves the structure of the test suite.
- Updating the `pdm.lock` file to reflect the changes in `pyproject.toml`.

With these changes, all tests now pass successfully in the CI environment.