### PR TITLE
fix: Use timezone.utc for Python 3.10 compatibility

### DIFF
--- a/src/py_load_eurostat/models.py
+++ b/src/py_load_eurostat/models.py
@@ -7,7 +7,7 @@ observational data. These models are used as Data Transfer Objects (DTOs)
 between the different layers of the pipeline.
 """
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Optional
 
@@ -176,7 +176,7 @@ class IngestionHistory(BaseModel):
         description="The current status of the ingestion.",
     )
     start_time: datetime = Field(
-        default_factory=lambda: datetime.now(UTC),
+        default_factory=lambda: datetime.now(timezone.utc),
         description="The start time of the ingestion process.",
     )
     end_time: Optional[datetime] = Field(


### PR DESCRIPTION
Replaced `datetime.UTC` with `datetime.timezone.utc` to ensure compatibility with Python 3.10, as the former was introduced in Python 3.11. This resolves the `ImportError` that was causing the test suite to fail in the CI environment.