### PR TITLE
feat: Add code coverage reporting to CI (#67)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,9 @@ jobs:
         export PY_LOAD_EUROSTAT_DB__PASSWORD=testpassword
         export PY_LOAD_EUROSTAT_DB__NAME=testdb
         pdm run pytest
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        file: ./coverage.xml
+        fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ build/
 .mypy_cache/
 .ruff_cache/
 .coverage
+coverage.xml
+.coverage.*
 
 # OS-specific
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ check_untyped_defs = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q --cov=src/py_load_eurostat --cov-report=term-missing"
+addopts = "-ra -q --cov=src/py_load_eurostat --cov-report=term-missing --cov-report=xml"
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
This commit introduces code coverage reporting to the CI pipeline.

Changes:
- Modified `pyproject.toml` to generate a `coverage.xml` report using `pytest-cov`.
- Updated the GitHub Actions workflow (`.github/workflows/ci.yml`) to upload the coverage report to Codecov using the `codecov/codecov-action`.
- Added `coverage.xml` and `.coverage.*` to `.gitignore` to prevent build artifacts from being committed.