### PR TITLE
Fix Codecov token error in CI workflow (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
-        # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
The Codecov action was failing on the main branch because it's protected and requires a token to upload coverage reports. This change enables the token for the Codecov action.